### PR TITLE
Os matrix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: node_js
+
+matrix:
+  include:
+    - os: linux
+      dist: bionic
+      sudo: false
+    - os: windows
+    - os: osx
+
 node_js:
   - "10"
-dist: bionic
-sudo: false
-
 cache:
   directories:
     - node_modules
-
 addons:
   chrome: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - os: linux
       dist: bionic
       sudo: false
-    - os: windows
     - os: osx
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - npm run lint
   - npm run test:headless
   - npm run build
-  - xvfb-run npm run e2e
+  - npm run e2e

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In addition to what is currently (13.09.2018) listed on [angular.io](https://ang
 - Run tests in parallel using [karma-parallel](https://www.npmjs.com/package/karma-parallel)
 - Correct `tslint` warnings and errors
 - Add `pre-commit` hook
-- Add [Travis-CI](https://travis-ci.org/ammarnajjar/angular-tour-of-heroes) build pipeline
+- Add [Travis-CI](https://travis-ci.org/ammarnajjar/angular-tour-of-heroes) build pipelines (Ubuntu & OSX)
 - Add [Heroku](https://angular-demon.herokuapp.com) deployment
 - Add [Greenkeeper](https://greenkeeper.io/) dependencies monitoring
 - Add [david-dm](https://david-dm.org/ammarnajjar/angular-tour-of-heroes) dependencies check

--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -13,7 +13,12 @@ exports.config = {
     // For Travis CI only
     chromeOptions: {
       binary: process.env.CHROME_BIN,
-      args: ['--no-sandbox']
+      args: [
+          '--headless',
+          '--disable-gpu',
+          '--no-sandbox',
+          '--remote-debugging-port=9222'
+      ]
     }
   },
   directConnect: true,


### PR DESCRIPTION
- add Ubuntu bionic und OSX os matrix for travis builds
- make e2e tests run headless